### PR TITLE
Allow text or html or both, but not neither

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mhart/alpine-node:6.10.0
+
+# Create app directory
+RUN mkdir -p /aws-ses-local
+WORKDIR /aws-ses-local
+
+# Install app dependencies
+COPY package.json /aws-ses-local
+COPY .babelrc /aws-ses-local
+
+RUN npm install --loglevel=silent
+
+# Copy app source
+COPY src /aws-ses-local/src
+
+RUN npm run prepublish
+
+ENV PORT=9001
+EXPOSE 9001
+
+CMD [ "npm", "start"]

--- a/src/server-spec.js
+++ b/src/server-spec.js
@@ -46,6 +46,42 @@ describe('/POST email', () => {
         done()
       })
   })
+  it('should succeed if only HTML body is missing', (done) => {
+    chai.request(server)
+      .post('/')
+      .send({
+        Action: 'SendEmail',
+        'Destination.ToAddresses.member.1': toAddress,
+        'Message.Body.Text.Data': textEmail,
+        'Message.Subject.Data': emailSubject,
+        'Destination.CcAddresses.member.1': ccAddress,
+        'Destination.BccAddresses.member.1': bccAddress,
+        'ReplyToAddresses.member.1': replyToAddress,
+        Source: fromEmail,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
+  it('should succeed if only Text body is missing', (done) => {
+    chai.request(server)
+      .post('/')
+      .send({
+        Action: 'SendEmail',
+        'Destination.ToAddresses.member.1': toAddress,
+        'Message.Body.Html.Data': htmlEmail,
+        'Message.Subject.Data': emailSubject,
+        'Destination.CcAddresses.member.1': ccAddress,
+        'Destination.BccAddresses.member.1': bccAddress,
+        'ReplyToAddresses.member.1': replyToAddress,
+        Source: fromEmail,
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
   it('should fail if one param is not sent', (done) => {
     chai.request(server)
       .post('/')

--- a/src/server.js
+++ b/src/server.js
@@ -38,7 +38,7 @@ app.post('/', (req, res) => {
     const fullDir = `${dateDir}/${dateTime.slice(11, 22).replace(/:\s*/g, '.')}`
     const headers = `Subject: ${req.body['Message.Subject.Data']}\nTo Address: ${req.body['Destination.ToAddresses.member.1']}\nCc Address: ${req.body['Destination.CcAddresses.member.1']}\nBcc Address: ${req.body['Destination.BccAddresses.member.1']}\nReply To Address: ${req.body['ReplyToAddresses.member.1']}\nSource: ${req.body.Source}`
     try {
-      if (req.body.Source && req.body['Message.Subject.Data'] && req.body['Message.Body.Html.Data'] && req.body['Message.Body.Text.Data'] && req.body['Destination.ToAddresses.member.1']) {
+      if (req.body.Source && req.body['Message.Subject.Data'] && (req.body['Message.Body.Html.Data'] || req.body['Message.Body.Text.Data']) && req.body['Destination.ToAddresses.member.1']) {
         mkdir(path.join(dateDir))
         mkdir(path.join(fullDir))
         log(`  📬  ${chalk.green('Email Received')}


### PR DESCRIPTION
I originally made a PR for this change against [jdelibas'](https://github.com/jdelibas/aws-ses-local/pull/1) fork, seeing as that one has a Dockerfile. But there's been no response there, and it seems you've made changes in the last few months, so I was hoping you might take a look at this 🙂 

Details copied over from the other PR:

---

Currently aws-ses-local requires that both html and text bodies be present.

If you try manually sending a request to the real SES, you'll find that it does allow you to omit one of them (as long as you have the other).

This PR makes it so that requests succeed as long as at least one of the two has been given.