### PR TITLE
Implement SendRawEmail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '5.6.0'
+  - '5.10.0'
 script:
   - npm run lint
   - npm test

--- a/src/send-email.js
+++ b/src/send-email.js
@@ -1,0 +1,39 @@
+import path from 'path'
+import chalk from 'chalk'
+import fs from 'fs'
+import mkdir from './library/mkdir'
+
+const successTemplate = fs.readFileSync(`${__dirname}/templates/success.xml`, { encoding: 'utf-8' })
+const errorTemplate = fs.readFileSync(`${__dirname}/templates/error.xml`, { encoding: 'utf-8' })
+
+const sendEmail = (req, res, dateDir, fullDir, log) => {
+  const headers = `Subject: ${req.body['Message.Subject.Data']}\nTo Address: ${req.body['Destination.ToAddresses.member.1']}\nCc Address: ${req.body['Destination.CcAddresses.member.1']}\nBcc Address: ${req.body['Destination.BccAddresses.member.1']}\nReply To Address: ${req.body['ReplyToAddresses.member.1']}\nSource: ${req.body.Source}`
+  try {
+    if (req.body.Source && req.body['Message.Subject.Data'] && (req.body['Message.Body.Html.Data'] || req.body['Message.Body.Text.Data']) && req.body['Destination.ToAddresses.member.1']) {
+      mkdir(path.join(dateDir))
+      mkdir(path.join(fullDir))
+      log(`  📬  ${chalk.green('Email Received')}
+        ${chalk.blue('From:')} ${req.body.Source}
+        ${chalk.blue('To:')} ${req.body['Destination.ToAddresses.member.1']}
+        ${chalk.blue('Subject:')} ${req.body['Message.Subject.Data']}
+        ${chalk.blue('Html Email:')} ${process.cwd()}/${path.join(fullDir)}/body.html
+        ${chalk.blue('Text Email:')} ${process.cwd()}/${path.join(fullDir)}/body.txt
+      `)
+      fs.writeFileSync(`${fullDir}/body.html`, req.body['Message.Body.Html.Data'])
+      fs.writeFileSync(`${fullDir}/body.txt`, req.body['Message.Body.Text.Data'])
+      fs.writeFileSync(`${fullDir}/headers.txt`, headers)
+      res.status(200).send(
+        successTemplate.replace('{{message}}', `${process.cwd()}/${path.join(fullDir)}/body.html`)
+      )
+    } else {
+      throw new Error('One or more required fields was not sent')
+    }
+  } catch (err) {
+    log(`   ${chalk.red('Error Occured:')} ${err}`)
+    res.status(500).send(
+      errorTemplate.replace('{{code}}', 'MessageRejected').replace('{{message}}', err.message)
+    )
+  }
+}
+
+export default sendEmail

--- a/src/send-email.js
+++ b/src/send-email.js
@@ -4,36 +4,29 @@ import fs from 'fs'
 import mkdir from './library/mkdir'
 
 const successTemplate = fs.readFileSync(`${__dirname}/templates/success.xml`, { encoding: 'utf-8' })
-const errorTemplate = fs.readFileSync(`${__dirname}/templates/error.xml`, { encoding: 'utf-8' })
 
 const sendEmail = (req, res, dateDir, fullDir, log) => {
   const headers = `Subject: ${req.body['Message.Subject.Data']}\nTo Address: ${req.body['Destination.ToAddresses.member.1']}\nCc Address: ${req.body['Destination.CcAddresses.member.1']}\nBcc Address: ${req.body['Destination.BccAddresses.member.1']}\nReply To Address: ${req.body['ReplyToAddresses.member.1']}\nSource: ${req.body.Source}`
-  try {
-    if (req.body.Source && req.body['Message.Subject.Data'] && (req.body['Message.Body.Html.Data'] || req.body['Message.Body.Text.Data']) && req.body['Destination.ToAddresses.member.1']) {
-      mkdir(path.join(dateDir))
-      mkdir(path.join(fullDir))
-      log(`  📬  ${chalk.green('Email Received')}
-        ${chalk.blue('From:')} ${req.body.Source}
-        ${chalk.blue('To:')} ${req.body['Destination.ToAddresses.member.1']}
-        ${chalk.blue('Subject:')} ${req.body['Message.Subject.Data']}
-        ${chalk.blue('Html Email:')} ${process.cwd()}/${path.join(fullDir)}/body.html
-        ${chalk.blue('Text Email:')} ${process.cwd()}/${path.join(fullDir)}/body.txt
-      `)
-      fs.writeFileSync(`${fullDir}/body.html`, req.body['Message.Body.Html.Data'])
-      fs.writeFileSync(`${fullDir}/body.txt`, req.body['Message.Body.Text.Data'])
-      fs.writeFileSync(`${fullDir}/headers.txt`, headers)
-      res.status(200).send(
-        successTemplate.replace('{{message}}', `${process.cwd()}/${path.join(fullDir)}/body.html`)
-      )
-    } else {
-      throw new Error('One or more required fields was not sent')
-    }
-  } catch (err) {
-    log(`   ${chalk.red('Error Occured:')} ${err}`)
-    res.status(500).send(
-      errorTemplate.replace('{{code}}', 'MessageRejected').replace('{{message}}', err.message)
-    )
+
+  if (!(req.body.Source && req.body['Message.Subject.Data'] && (req.body['Message.Body.Html.Data'] || req.body['Message.Body.Text.Data']) && req.body['Destination.ToAddresses.member.1'])) {
+    throw new Error('One or more required fields was not sent')
   }
+
+  mkdir(path.join(dateDir))
+  mkdir(path.join(fullDir))
+  log(`  📬  ${chalk.green('Email Received')}
+    ${chalk.blue('From:')} ${req.body.Source}
+    ${chalk.blue('To:')} ${req.body['Destination.ToAddresses.member.1']}
+    ${chalk.blue('Subject:')} ${req.body['Message.Subject.Data']}
+    ${chalk.blue('Html Email:')} ${process.cwd()}/${path.join(fullDir)}/body.html
+    ${chalk.blue('Text Email:')} ${process.cwd()}/${path.join(fullDir)}/body.txt
+  `)
+  fs.writeFileSync(`${fullDir}/body.html`, req.body['Message.Body.Html.Data'])
+  fs.writeFileSync(`${fullDir}/body.txt`, req.body['Message.Body.Text.Data'])
+  fs.writeFileSync(`${fullDir}/headers.txt`, headers)
+  res.status(200).send(
+    successTemplate.replace('{{message}}', `${process.cwd()}/${path.join(fullDir)}/body.html`)
+  )
 }
 
 export default sendEmail

--- a/src/send-raw-email.js
+++ b/src/send-raw-email.js
@@ -1,0 +1,28 @@
+import path from 'path'
+import chalk from 'chalk'
+import fs from 'fs'
+import mkdir from './library/mkdir'
+
+const successTemplate = fs.readFileSync(`${__dirname}/templates/success.xml`, { encoding: 'utf-8' })
+
+const sendRawEmail = (req, res, dateDir, fullDir, log) => {
+  if (!req.body['RawMessage.Data']) {
+    throw new Error('RawMessage.Data is required and was not sent')
+  }
+
+  mkdir(path.join(dateDir))
+  mkdir(path.join(fullDir))
+  log(`  🍣  ${chalk.green('Raw Email Received')}
+    ${chalk.blue('From:')} ${req.body.Source}
+    ${chalk.blue('To:')} ${req.body['Destinations.member.1']}
+    ${chalk.blue('Raw Message:')} ${process.cwd()}/${path.join(fullDir)}/raw-message
+  `)
+  const decodedBody = Buffer.from(req.body['RawMessage.Data'], 'base64').toString()
+  fs.writeFileSync(`${fullDir}/raw-message`, decodedBody)
+
+  res.status(200).send(
+    successTemplate.replace('{{message}}', `${process.cwd()}/${path.join(fullDir)}/raw-message`)
+  )
+}
+
+module.exports = sendRawEmail

--- a/src/server-spec.js
+++ b/src/server-spec.js
@@ -13,7 +13,7 @@ chai.use(chaiHttp)
 //   })
 // })
 
-describe('/POST email', () => {
+describe('/POST SendEmail', () => {
   const toAddress = 'to@email.com'
   const ccAddress = 'cc@email.com'
   const bccAddress = 'bcc@email.com'
@@ -97,6 +97,21 @@ describe('/POST email', () => {
         const response = new xmldoc.XmlDocument(res.text)
         expect(response.valueWithPath('Code')).to.eq('MessageRejected')
         expect(response.valueWithPath('Message')).to.eq('One or more required fields was not sent')
+        done()
+      })
+  })
+})
+
+describe('/POST Unsupported action', () => {
+  it('should fail if the action is not unsupported', (done) => {
+    chai.request(server)
+      .post('/')
+      .send({ Action: 'SomeRandomAction' })
+      .end((err, res) => {
+        expect(res).to.have.status(500)
+        const response = new xmldoc.XmlDocument(res.text)
+        expect(response.valueWithPath('Code')).to.eq('MessageRejected')
+        expect(response.valueWithPath('Message')).to.eq('Unsupported action SomeRandomAction')
         done()
       })
   })

--- a/src/server.js
+++ b/src/server.js
@@ -5,16 +5,14 @@ import express from 'express'
 import bodyParser from 'body-parser'
 import path from 'path'
 import chalk from 'chalk'
-import fs from 'fs'
 // Import local libs
 import mkdir from './library/mkdir'
 import options from './library/options'
 import rmdir from './library/rmdir'
+import sendEmail from './send-email'
 
 const app = express()
 const log = console.log //eslint-disable-line
-const successTemplate = fs.readFileSync(`${__dirname}/templates/success.xml`, { encoding: 'utf-8' })
-const errorTemplate = fs.readFileSync(`${__dirname}/templates/error.xml`, { encoding: 'utf-8' })
 
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
@@ -33,36 +31,11 @@ mkdir(path.join(options.outputDir))
 
 app.post('/', (req, res) => {
   const dateTime = new Date().toISOString()
+  const dateDir = `${options.outputDir}/${dateTime.slice(0, 10)}`
+  const fullDir = `${dateDir}/${dateTime.slice(11, 22).replace(/:\s*/g, '.')}`
+
   if (req.body.Action === 'SendEmail') {
-    const dateDir = `${options.outputDir}/${dateTime.slice(0, 10)}`
-    const fullDir = `${dateDir}/${dateTime.slice(11, 22).replace(/:\s*/g, '.')}`
-    const headers = `Subject: ${req.body['Message.Subject.Data']}\nTo Address: ${req.body['Destination.ToAddresses.member.1']}\nCc Address: ${req.body['Destination.CcAddresses.member.1']}\nBcc Address: ${req.body['Destination.BccAddresses.member.1']}\nReply To Address: ${req.body['ReplyToAddresses.member.1']}\nSource: ${req.body.Source}`
-    try {
-      if (req.body.Source && req.body['Message.Subject.Data'] && (req.body['Message.Body.Html.Data'] || req.body['Message.Body.Text.Data']) && req.body['Destination.ToAddresses.member.1']) {
-        mkdir(path.join(dateDir))
-        mkdir(path.join(fullDir))
-        log(`  📬  ${chalk.green('Email Received')}
-          ${chalk.blue('From:')} ${req.body.Source}
-          ${chalk.blue('To:')} ${req.body['Destination.ToAddresses.member.1']}
-          ${chalk.blue('Subject:')} ${req.body['Message.Subject.Data']}
-          ${chalk.blue('Html Email:')} ${process.cwd()}/${path.join(fullDir)}/body.html
-          ${chalk.blue('Text Email:')} ${process.cwd()}/${path.join(fullDir)}/body.txt
-        `)
-        fs.writeFileSync(`${fullDir}/body.html`, req.body['Message.Body.Html.Data'])
-        fs.writeFileSync(`${fullDir}/body.txt`, req.body['Message.Body.Text.Data'])
-        fs.writeFileSync(`${fullDir}/headers.txt`, headers)
-        res.status(200).send(
-          successTemplate.replace('{{message}}', `${process.cwd()}/${path.join(fullDir)}/body.html`)
-        )
-      } else {
-        throw new Error('One or more required fields was not sent')
-      }
-    } catch (err) {
-      log(`   ${chalk.red('Error Occured:')} ${err}`)
-      res.status(500).send(
-        errorTemplate.replace('{{code}}', 'MessageRejected').replace('{{message}}', err.message)
-      )
-    }
+    sendEmail(req, res, dateDir, fullDir, log)
   }
 })
 

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import mkdir from './library/mkdir'
 import options from './library/options'
 import rmdir from './library/rmdir'
 import sendEmail from './send-email'
+import sendRawEmail from './send-raw-email'
 
 const app = express()
 const log = console.log //eslint-disable-line
@@ -41,6 +42,9 @@ app.post('/', (req, res) => {
     switch (req.body.Action) {
       case 'SendEmail':
         sendEmail(req, res, dateDir, fullDir, log)
+        break
+      case 'SendRawEmail':
+        sendRawEmail(req, res, dateDir, fullDir, log)
         break
       default:
         throw new Error(`Unsupported action ${req.body.Action}`)


### PR DESCRIPTION
Resolves #5.

**Changes:**
- Implements the SendRawEmail function, including base64 decoding of the raw message
- Responds with an error to unsupported actions. Previously it would just never respond, leaving the client to eventually time out
- Wrote unit tests for new code
- Upgraded node version on travis from 5.6 to 5.10, in order to use `Buffer.from`
- Chose the sushi emoji 🍣 to represent 'raw' email requests 😁 
- Tested it manually and it works!

**Notes for reviewer:**
The diff, when viewed all at once, looks a bit scary because:

- The first commit extracts a bunch of code into a separate module
- The second commit contains a big de-dentation which makes it look like I changed a bunch of lines when really it's just whitespace

So to make the review easier, I recommend:
- Reviewing one commit at a time rather than all at once; and
- Put `?w=1` onto the end of the github URL, which makes it hide whitespace changes so you can see what actually changed

Happy to make changes wherever needed 🙂 